### PR TITLE
Feat/capture video audio from robot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,10 @@ __pycache__
 *.pyo
 *.pyd
 
-# Logs and runtime data 
+# Logs and runtime data
 logs
 ollama_data
+recordings
 
 # Local tooling 
 .claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y \
     libgl1 \
     libglib2.0-0 \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the requirements file into the container

--- a/pepper_wizard/cli.py
+++ b/pepper_wizard/cli.py
@@ -109,6 +109,12 @@ def show_main_menu(teleop_state):
         else:
              return f"Robot State [<ansired>{state}</ansired>]"
 
+    def format_record_label(is_recording):
+        if is_recording:
+            return f"Record [<ansired><b>● REC</b></ansired>]"
+        else:
+             return f"Record [<ansibrightblack>○ Off</ansibrightblack>]"
+
     def format_tracking_label(mode):
         if mode == "Head":
              return f"Tracking Mode [<ansimagenta>{mode}</ansimagenta>]"
@@ -167,7 +173,6 @@ def show_main_menu(teleop_state):
     options = [
         ("t", format_talk_label(teleop_state.get('talk_mode', 'Voice'))),
         ("j", format_teleop_label(current_mode)),
-        ("r", f"Record [{'On' if teleop_state.get('record', False) else 'Off'}]"),
         ("a", format_social_label(teleop_state.get('social_mode', 'Disabled'))),
         ("s", format_tracking_label(teleop_state.get('tracking_mode', 'Head'))),
         ("w", format_robot_state_label(teleop_state.get('robot_state', 'Rest'))),
@@ -177,6 +182,7 @@ def show_main_menu(teleop_state):
         options.append(("tr", "Track Object"))
     options.extend([
         ("tm", "Joint Temperatures"),
+        ("r", format_record_label(teleop_state.get('record', False))),
         ("exit", "Exit Application"),
     ])
     

--- a/pepper_wizard/cli.py
+++ b/pepper_wizard/cli.py
@@ -167,6 +167,7 @@ def show_main_menu(teleop_state):
     options = [
         ("t", format_talk_label(teleop_state.get('talk_mode', 'Voice'))),
         ("j", format_teleop_label(current_mode)),
+        ("r", f"Record [{'On' if teleop_state.get('record', False) else 'Off'}]"),
         ("a", format_social_label(teleop_state.get('social_mode', 'Disabled'))),
         ("s", format_tracking_label(teleop_state.get('tracking_mode', 'Head'))),
         ("w", format_robot_state_label(teleop_state.get('robot_state', 'Rest'))),

--- a/pepper_wizard/command_handler.py
+++ b/pepper_wizard/command_handler.py
@@ -59,10 +59,11 @@ class ZMQCommandListener(threading.Thread):
 
 class CommandHandler:
     """Handles user commands and dispatches them to the correct functions."""
-    def __init__(self, robot_client, config, verbose=False):
+    def __init__(self, robot_client, config, verbose=False, recorder=None):
         self.robot_client = robot_client
         self.config = config
         self.verbose = verbose
+        self.recorder = recorder  # RecordingController, optional
         self.teleop_thread = None
         self.tracking_modes = ["Head", "WholeBody", "Move"]
         self.current_mode_index = 0
@@ -144,6 +145,13 @@ class CommandHandler:
                       print("!!! Social State Enabled: Deactivating Tracking Override...")
                       self.tracker.set_target(None)
                       self.suppressed_social_state = False
+        elif command == 'r':
+            if self.recorder is None:
+                print("Recorder not configured.")
+            else:
+                self.recorder.toggle()
+                if teleop_state is not None:
+                    teleop_state['record'] = self.recorder.is_recording
         elif command == 't':
             talk_mode = teleop_state.get('talk_mode', 'Voice') if teleop_state else 'Voice'
             if talk_mode == 'Voice':

--- a/pepper_wizard/command_handler.py
+++ b/pepper_wizard/command_handler.py
@@ -63,7 +63,7 @@ class CommandHandler:
         self.robot_client = robot_client
         self.config = config
         self.verbose = verbose
-        self.recorder = recorder  # RecordingController, optional
+        self.recorder = recorder 
         self.teleop_thread = None
         self.tracking_modes = ["Head", "WholeBody", "Move"]
         self.current_mode_index = 0

--- a/pepper_wizard/config.py
+++ b/pepper_wizard/config.py
@@ -121,7 +121,7 @@ def load_stt_config(file_path):
 def load_recording_config(file_path):
     """Loads recording configuration from a JSON file."""
     defaults = {
-        "record_by_default": True,
+        "record_by_default": False,
         "output_dir": "recordings",
         "video_codec": "ffv1",
         "video_pix_fmt": "yuv420p",

--- a/pepper_wizard/config.py
+++ b/pepper_wizard/config.py
@@ -118,6 +118,26 @@ def load_stt_config(file_path):
         print(f"Error loading STT config from {file_path}: {e}")
         return defaults
 
+def load_recording_config(file_path):
+    """Loads recording configuration from a JSON file."""
+    defaults = {
+        "record_by_default": True,
+        "output_dir": "recordings",
+        "video_codec": "ffv1",
+        "video_pix_fmt": "yuv420p",
+        "audio_codec": "pcm_s16le",
+        "container": "mkv",
+    }
+    try:
+        with open(file_path, "r") as f:
+            user = json.load(f)
+        merged = {**defaults, **user}
+        print("Recording config loaded successfully.")
+        return merged
+    except (IOError, json.JSONDecodeError) as e:
+        print(f"Error loading recording config from {file_path}: {e}. Using defaults.")
+        return defaults
+
 class Config:
     """A class to hold the application configuration."""
     def __init__(self):
@@ -130,6 +150,7 @@ class Config:
         self.temperature_config = load_temperature_config(CONFIG_DIR / "temperature.json")
         self.stt_config = load_stt_config(CONFIG_DIR / "stt.json")
         self.llm_config = load_llm_config(CONFIG_DIR / "llm.json")
+        self.recording_config = load_recording_config(CONFIG_DIR / "recording.json")
 
 def load_config():
     """Load all configurations."""

--- a/pepper_wizard/config.py
+++ b/pepper_wizard/config.py
@@ -127,6 +127,9 @@ def load_recording_config(file_path):
         "video_pix_fmt": "yuv420p",
         "audio_codec": "pcm_s16le",
         "container": "mkv",
+        "video_resolution": [320, 240],
+        "audio_sample_rate": 16000,
+        "audio_channels": 1,
     }
     try:
         with open(file_path, "r") as f:

--- a/pepper_wizard/config/recording.json
+++ b/pepper_wizard/config/recording.json
@@ -1,5 +1,5 @@
 {
-    "record_by_default": true,
+    "record_by_default": false,
     "output_dir": "recordings",
     "video_codec": "ffv1",
     "video_pix_fmt": "yuv420p",

--- a/pepper_wizard/config/recording.json
+++ b/pepper_wizard/config/recording.json
@@ -4,5 +4,8 @@
     "video_codec": "ffv1",
     "video_pix_fmt": "yuv420p",
     "audio_codec": "pcm_s16le",
-    "container": "mkv"
+    "container": "mkv",
+    "video_resolution": [320, 240],
+    "audio_sample_rate": 16000,
+    "audio_channels": 1
 }

--- a/pepper_wizard/config/recording.json
+++ b/pepper_wizard/config/recording.json
@@ -1,0 +1,8 @@
+{
+    "record_by_default": true,
+    "output_dir": "recordings",
+    "video_codec": "ffv1",
+    "video_pix_fmt": "yuv420p",
+    "audio_codec": "pcm_s16le",
+    "container": "mkv"
+}

--- a/pepper_wizard/main.py
+++ b/pepper_wizard/main.py
@@ -1,10 +1,12 @@
 # Main application entry point
 import argparse
+import signal
 import sys
 from . import cli
 from .config import load_config
 from .robot_client import RobotClient
 from .command_handler import CommandHandler
+from .recording import RecordingController
 
 from prompt_toolkit import PromptSession
 
@@ -39,7 +41,16 @@ def main():
 
     print(" --- PepperWizard Ready ---")
 
-    command_handler = CommandHandler(robot_client, config, verbose=args.verbose)
+    recording_controller = RecordingController(
+        config=config.recording_config,
+        session_id=args.session_id,
+        video_address="tcp://localhost:5559",
+        audio_address="tcp://localhost:5563",
+        clock_sync_url=f"http://{args.proxy_ip}:{args.proxy_port}/time",
+    )
+
+    command_handler = CommandHandler(robot_client, config, verbose=args.verbose,
+                                     recorder=recording_controller)
     
     # Teleop State (shared between CLI menu and CommandHandler)
     default_mode = config.teleop_config.get("default_mode", "Joystick")
@@ -51,6 +62,7 @@ def main():
 
     initial_tracking_mode = robot_client.get_tracking_mode() or "Head"
 
+    record_by_default = config.recording_config.get("record_by_default", False)
     teleop_state = {
         "mode": default_mode,
         "social_mode": social_mode_label,
@@ -58,7 +70,17 @@ def main():
         "tracking_mode": initial_tracking_mode,
         "battery": None,
         "tracker_available": command_handler.tracker is not None,
+        "record": record_by_default,
     }
+    if record_by_default:
+        recording_controller.toggle()
+
+    def _finalise_recording_on_signal(_sig, _frame):
+        paths = recording_controller.stop_if_recording()
+        if paths:
+            print(f"Recording finalised on signal: {paths['mkv']}")
+        raise SystemExit(0)
+    signal.signal(signal.SIGTERM, _finalise_recording_on_signal)
 
     # Start robot status polling thread
     import threading
@@ -111,8 +133,11 @@ def main():
         print("\nCaught KeyboardInterrupt. Shutting down...")
         logger.info("ApplicationShutdown", {"reason": "KeyboardInterrupt"})
     finally:
+        paths = recording_controller.stop_if_recording()
+        if paths:
+            print(f"Recording finalised: {paths['mkv']}")
         command_handler.cleanup()
-    
+
     print(" --- Exiting Pepper Wizard ---")
 
 if __name__ == "__main__":

--- a/pepper_wizard/recording/__init__.py
+++ b/pepper_wizard/recording/__init__.py
@@ -1,0 +1,1 @@
+"""Recording subsystem: synchronised A/V capture with sidecar JSONL timestamps."""

--- a/pepper_wizard/recording/__init__.py
+++ b/pepper_wizard/recording/__init__.py
@@ -1,1 +1,4 @@
 """Recording subsystem: synchronised A/V capture with sidecar JSONL timestamps."""
+from .recorder import Recorder, RecordingController
+
+__all__ = ["Recorder", "RecordingController"]

--- a/pepper_wizard/recording/audio_sink.py
+++ b/pepper_wizard/recording/audio_sink.py
@@ -1,0 +1,60 @@
+"""ZMQ audio subscriber that timestamps int16 PCM chunks and enqueues them.
+
+Subscribes to the PepperBox audio PUB stream (default tcp://localhost:5563).
+Wire format: single frame of raw bytes, int16 little-endian, mono, 16 kHz.
+Default chunk size is 2720 samples (5440 bytes = 170 ms) but the sink does
+not enforce a fixed size — it forwards whatever chunk size the publisher sends.
+
+Output queue payload:
+  {
+    "ingest_utc_ns": int,
+    "pcm_bytes": bytes,
+    "samples": int,
+    "chunk_index": int,
+  }
+"""
+import threading
+import time
+
+import zmq
+
+
+class AudioSink(threading.Thread):
+    SAMPLE_BYTES = 2
+
+    def __init__(self, zmq_address, out_queue):
+        super().__init__(daemon=True)
+        self.zmq_address = zmq_address
+        self.out_queue = out_queue
+        self._stop_evt = threading.Event()
+        self._chunk_index = 0
+
+    def stop(self):
+        # _stop is an internal slot on threading.Thread; keep our Event as _stop_evt.
+        self._stop_evt.set()
+
+    def run(self):
+        ctx = zmq.Context.instance()
+        sock = ctx.socket(zmq.SUB)
+        sock.connect(self.zmq_address)
+        sock.setsockopt(zmq.SUBSCRIBE, b"")
+        sock.setsockopt(zmq.RCVTIMEO, 200)
+
+        try:
+            while not self._stop_evt.is_set():
+                try:
+                    chunk = sock.recv()
+                except zmq.Again:
+                    continue
+                ingest_ns = time.time_ns()
+                if len(chunk) % self.SAMPLE_BYTES != 0:
+                    continue
+                self.out_queue.put({
+                    "ingest_utc_ns": ingest_ns,
+                    "pcm_bytes": chunk,
+                    "samples": len(chunk) // self.SAMPLE_BYTES,
+                    "chunk_index": self._chunk_index,
+                })
+                self._chunk_index += 1
+        finally:
+            sock.close(linger=0)

--- a/pepper_wizard/recording/clock_sync.py
+++ b/pepper_wizard/recording/clock_sync.py
@@ -1,0 +1,55 @@
+"""Robot↔wizard clock-sync probe.
+
+Sends N HTTP round-trips to a /time endpoint on the PepperBox shim.
+Each round-trip records (t_send, t_recv, t_server) on the wizard wall-clock.
+The minimum round-trip half-time is taken as the one-way latency estimate;
+the offset is then inferred so that adding it to a robot timestamp yields
+wall-clock UTC.
+
+If no robot-side endpoint exists / probe fails, returns None.
+"""
+import json
+import time
+import urllib.error
+import urllib.request
+
+
+def probe_clock_sync(url, samples=10, timeout_s=2.0):
+    """Probe the given /time URL N times; return a dict with offset estimate or None.
+
+    Returns:
+        {"robot_offset_ns": int, "min_rtt_ns": int, "samples": int}
+        such that wizard_utc_ns ≈ robot_clock_ns + robot_offset_ns
+        OR None if every attempt failed.
+    """
+    successes = []
+    for _ in range(samples):
+        t_send = time.time_ns()
+        try:
+            with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+                body = resp.read()
+        except (urllib.error.URLError, OSError, TimeoutError):
+            continue
+        t_recv = time.time_ns()
+        try:
+            payload = json.loads(body)
+            t_server = int(payload["now_ns"])
+        except (ValueError, KeyError, TypeError):
+            continue
+        successes.append((t_send, t_recv, t_server))
+
+    if not successes:
+        return None
+
+    successes.sort(key=lambda x: x[1] - x[0])
+    t_send, t_recv, t_server = successes[0]
+    min_rtt_ns = t_recv - t_send
+    one_way_ns = min_rtt_ns // 2
+    expected_wizard_ns_at_server = t_send + one_way_ns
+    robot_offset_ns = expected_wizard_ns_at_server - t_server
+
+    return {
+        "robot_offset_ns": int(robot_offset_ns),
+        "min_rtt_ns": int(min_rtt_ns),
+        "samples": len(successes),
+    }

--- a/pepper_wizard/recording/muxer.py
+++ b/pepper_wizard/recording/muxer.py
@@ -1,0 +1,88 @@
+"""PyAV-based MKV muxer for synchronised A/V recording.
+
+Owns a single OutputContainer with one video and one audio stream.
+Callers feed it frames (write_video_frame) and audio chunks (write_audio_chunk),
+each tagged with a presentation timestamp in milliseconds since recording start.
+
+PyAV is thread-safe across separate streams within one container, but each
+stream's encoder is not — callers must not interleave write_video_frame()
+calls across multiple threads, nor write_audio_chunk(). The Recorder uses
+two dedicated drain threads (one per stream) which satisfies this.
+"""
+import threading
+from fractions import Fraction
+
+import av
+import numpy as np
+
+
+class MkvMuxer:
+    VIDEO_TIMEBASE_MS = 1000  # 1 unit = 1 ms
+
+    def __init__(self, path, video_codec, video_pix_fmt, audio_codec,
+                 video_size, audio_sample_rate, audio_channels):
+        self._path = path
+        self._lock = threading.Lock()
+        self._closed = False
+
+        self._container = av.open(path, mode="w", format="matroska")
+
+        self._vstream = self._container.add_stream(video_codec, rate=30)
+        self._vstream.width, self._vstream.height = video_size
+        self._vstream.pix_fmt = video_pix_fmt
+        self._vstream.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)
+
+        self._astream = self._container.add_stream(audio_codec, rate=audio_sample_rate)
+        self._astream.layout = "mono" if audio_channels == 1 else "stereo"
+        self._astream.format = "s16"
+        self._astream.time_base = Fraction(1, audio_sample_rate)
+
+        self._video_size = video_size
+        self._audio_sample_rate = audio_sample_rate
+        self._audio_channels = audio_channels
+
+    def write_video_frame(self, gray_bytes, pts_ms):
+        if self._closed:
+            return
+        w, h = self._video_size
+        if len(gray_bytes) != w * h:
+            return
+        arr = np.frombuffer(gray_bytes, dtype=np.uint8).reshape((h, w))
+        frame = av.VideoFrame.from_ndarray(arr, format="gray")
+        frame = frame.reformat(format=self._vstream.pix_fmt)
+        frame.pts = int(pts_ms)
+        for packet in self._vstream.encode(frame):
+            self._container.mux(packet)
+
+    def write_audio_chunk(self, pcm_bytes, pts_ms):
+        if self._closed:
+            return
+        samples = np.frombuffer(pcm_bytes, dtype=np.int16)
+        if samples.size == 0:
+            return
+        arr = samples.reshape(1, -1)
+        frame = av.AudioFrame.from_ndarray(arr, format="s16", layout=self._astream.layout)
+        frame.sample_rate = self._audio_sample_rate
+        frame.pts = int(pts_ms) * self._audio_sample_rate // 1000
+        for packet in self._astream.encode(frame):
+            self._container.mux(packet)
+
+    def close(self):
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            for packet in self._vstream.encode():
+                self._container.mux(packet)
+        except Exception:
+            pass
+        try:
+            for packet in self._astream.encode():
+                self._container.mux(packet)
+        except Exception:
+            pass
+        try:
+            self._container.close()
+        except Exception:
+            pass

--- a/pepper_wizard/recording/muxer.py
+++ b/pepper_wizard/recording/muxer.py
@@ -54,7 +54,12 @@ class MkvMuxer:
         arr = np.frombuffer(gray_bytes, dtype=np.uint8).reshape((h, w))
         frame = av.VideoFrame.from_ndarray(arr, format="gray")
         frame = frame.reformat(format=self._vstream.pix_fmt)
+        # CRITICAL: pin frame.time_base explicitly. Without this, PyAV treats
+        # the frame's pts in the codec's default rate (24fps → 1/24s) then
+        # rescales to the stream's 1/1000s, multiplying every pts by ~41.67×
+        # (a 30s recording plays back as 1250s).
         frame.pts = int(pts_ms)
+        frame.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)
         for packet in self._vstream.encode(frame):
             self._container.mux(packet)
 
@@ -67,7 +72,12 @@ class MkvMuxer:
         arr = samples.reshape(1, -1)
         frame = av.AudioFrame.from_ndarray(arr, format="s16", layout=self._astream.layout)
         frame.sample_rate = self._audio_sample_rate
-        frame.pts = int(pts_ms) * self._audio_sample_rate // 1000
+        # Express pts in ms with a matching 1/1000 time_base. Matroska forces the
+        # stream's effective time_base to 1/1000 regardless of what we set, so
+        # using sample-based PTS would cause a 1/sample_rate*1000 = 1/16
+        # speed-up (audio plays 16× faster than wall clock).
+        frame.pts = int(pts_ms)
+        frame.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)
         for packet in self._astream.encode(frame):
             self._container.mux(packet)
 

--- a/pepper_wizard/recording/muxer.py
+++ b/pepper_wizard/recording/muxer.py
@@ -45,6 +45,14 @@ class MkvMuxer:
         self._audio_sample_rate = audio_sample_rate
         self._audio_channels = audio_channels
 
+        # Audio is paced sequentially in the MKV (continuous PCM stream),
+        # anchored to the first chunk's wall-clock pts_ms so it lines up with
+        # the video track at the start. The publisher delivers chunks with
+        # variable wall-clock gaps that don't reflect real audio time, so
+        # ingest-time PTS would leave silent gaps between every chunk.
+        self._audio_first_pts_ms = None
+        self._audio_total_samples = 0
+
     def write_video_frame(self, gray_bytes, pts_ms):
         if self._closed:
             return
@@ -72,11 +80,20 @@ class MkvMuxer:
         arr = samples.reshape(1, -1)
         frame = av.AudioFrame.from_ndarray(arr, format="s16", layout=self._astream.layout)
         frame.sample_rate = self._audio_sample_rate
-        # Express pts in ms with a matching 1/1000 time_base. Matroska forces the
-        # stream's effective time_base to 1/1000 regardless of what we set, so
-        # using sample-based PTS would cause a 1/sample_rate*1000 = 1/16
-        # speed-up (audio plays 16× faster than wall clock).
-        frame.pts = int(pts_ms)
+
+        # Anchor the audio track to the first chunk's wall-clock pts_ms, then
+        # pace subsequent chunks by their actual sample count. This produces a
+        # continuous PCM stream (no click-inducing gaps from variable publisher
+        # cadence) while still syncing the start of the audio track with the
+        # video track. Wall-clock truth lives in the sidecar; the MKV is the
+        # convenience artifact.
+        if self._audio_first_pts_ms is None:
+            self._audio_first_pts_ms = int(pts_ms)
+        chunk_pts_ms = self._audio_first_pts_ms + \
+            (self._audio_total_samples * 1000) // self._audio_sample_rate
+        self._audio_total_samples += samples.size
+
+        frame.pts = chunk_pts_ms
         frame.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)
         for packet in self._astream.encode(frame):
             self._container.mux(packet)

--- a/pepper_wizard/recording/muxer.py
+++ b/pepper_wizard/recording/muxer.py
@@ -27,7 +27,11 @@ class MkvMuxer:
 
         self._container = av.open(path, mode="w", format="matroska")
 
-        self._vstream = self._container.add_stream(video_codec, rate=30)
+        # Variable-rate video: do NOT pass `rate=` (which fixes time_base to 1/rate
+        # and causes PyAV/matroska to ignore subsequent time_base overrides — that's
+        # what made early recordings play back at 1/33 speed).  Set time_base
+        # explicitly to 1ms so frame.pts in ms matches stream time_base.
+        self._vstream = self._container.add_stream(video_codec)
         self._vstream.width, self._vstream.height = video_size
         self._vstream.pix_fmt = video_pix_fmt
         self._vstream.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)

--- a/pepper_wizard/recording/muxer.py
+++ b/pepper_wizard/recording/muxer.py
@@ -27,10 +27,9 @@ class MkvMuxer:
 
         self._container = av.open(path, mode="w", format="matroska")
 
-        # Variable-rate video: do NOT pass `rate=` (which fixes time_base to 1/rate
-        # and causes PyAV/matroska to ignore subsequent time_base overrides — that's
-        # what made early recordings play back at 1/33 speed).  Set time_base
-        # explicitly to 1ms so frame.pts in ms matches stream time_base.
+        # Variable-rate video: do NOT pass `rate=` (which fixes time_base to 1/rate)
+        # and causes PyAV/matroska to ignore subsequent time_base overrides 
+        # Set time_base explicitly to 1ms so frame.pts in ms matches stream time_base.
         self._vstream = self._container.add_stream(video_codec)
         self._vstream.width, self._vstream.height = video_size
         self._vstream.pix_fmt = video_pix_fmt
@@ -49,7 +48,7 @@ class MkvMuxer:
         # anchored to the first chunk's wall-clock pts_ms so it lines up with
         # the video track at the start. The publisher delivers chunks with
         # variable wall-clock gaps that don't reflect real audio time, so
-        # ingest-time PTS would leave silent gaps between every chunk.
+        # ingest-time PTS previously left silent gaps between every chunk.
         self._audio_first_pts_ms = None
         self._audio_total_samples = 0
 
@@ -62,10 +61,9 @@ class MkvMuxer:
         arr = np.frombuffer(gray_bytes, dtype=np.uint8).reshape((h, w))
         frame = av.VideoFrame.from_ndarray(arr, format="gray")
         frame = frame.reformat(format=self._vstream.pix_fmt)
-        # CRITICAL: pin frame.time_base explicitly. Without this, PyAV treats
+        # CRITICAL: pin frame.time_base explicitly. Without doing so PyAV treats
         # the frame's pts in the codec's default rate (24fps → 1/24s) then
-        # rescales to the stream's 1/1000s, multiplying every pts by ~41.67×
-        # (a 30s recording plays back as 1250s).
+        # rescales to the stream's 1/1000s.
         frame.pts = int(pts_ms)
         frame.time_base = Fraction(1, self.VIDEO_TIMEBASE_MS)
         for packet in self._vstream.encode(frame):
@@ -82,11 +80,7 @@ class MkvMuxer:
         frame.sample_rate = self._audio_sample_rate
 
         # Anchor the audio track to the first chunk's wall-clock pts_ms, then
-        # pace subsequent chunks by their actual sample count. This produces a
-        # continuous PCM stream (no click-inducing gaps from variable publisher
-        # cadence) while still syncing the start of the audio track with the
-        # video track. Wall-clock truth lives in the sidecar; the MKV is the
-        # convenience artifact.
+        # pace subsequent chunks by their actual sample count. 
         if self._audio_first_pts_ms is None:
             self._audio_first_pts_ms = int(pts_ms)
         chunk_pts_ms = self._audio_first_pts_ms + \

--- a/pepper_wizard/recording/recorder.py
+++ b/pepper_wizard/recording/recorder.py
@@ -24,22 +24,23 @@ from .sidecar import SidecarWriter
 from .video_sink import VideoSink
 
 
-VIDEO_RES_W = 320
-VIDEO_RES_H = 240
-AUDIO_SAMPLE_RATE = 16000
-AUDIO_CHANNELS = 1
-
-
 class Recorder:
     def __init__(self, config, session_id, video_address, audio_address,
                  clock_sync_url=None):
         self._config = dict(config)
-        # session_id is optional. When not set, file names omit the prefix and
-        # use the timestamp alone (matches the logger's behaviour for log files).
+        # session_id is optional.
         self._session_id = session_id or None
         self._video_address = video_address
         self._audio_address = audio_address
         self._clock_sync_url = clock_sync_url
+
+        # Hardware-derived stream parameters live in recording.json so the
+        # operator sees what the recorder is configured to capture without
+        # cracking open the source. Defaults in load_recording_config().
+        res = self._config.get("video_resolution", [320, 240])
+        self._video_res_w, self._video_res_h = int(res[0]), int(res[1])
+        self._audio_sample_rate = int(self._config.get("audio_sample_rate", 16000))
+        self._audio_channels = int(self._config.get("audio_channels", 1))
 
         self._started = False
         self._stopped = False
@@ -92,9 +93,9 @@ class Recorder:
             video_codec=self._config["video_codec"],
             video_pix_fmt=self._config["video_pix_fmt"],
             audio_codec=self._config["audio_codec"],
-            video_size=(VIDEO_RES_W, VIDEO_RES_H),
-            audio_sample_rate=AUDIO_SAMPLE_RATE,
-            audio_channels=AUDIO_CHANNELS,
+            video_size=(self._video_res_w, self._video_res_h),
+            audio_sample_rate=self._audio_sample_rate,
+            audio_channels=self._audio_channels,
         )
         self._sidecar = SidecarWriter(self._paths["jsonl"])
         self._sidecar.write_header({
@@ -102,8 +103,13 @@ class Recorder:
             "recording_start_utc_ns": self._t0_ns,
             "session_id": self._session_id,
             "clock_sync": clock_sync,
-            "video": {"address": self._video_address, "resolution": [VIDEO_RES_W, VIDEO_RES_H], "format": "y8"},
-            "audio": {"address": self._audio_address, "sample_rate": AUDIO_SAMPLE_RATE, "channels": AUDIO_CHANNELS, "dtype": "int16"},
+            "video": {"address": self._video_address,
+                      "resolution": [self._video_res_w, self._video_res_h],
+                      "format": "y8"},
+            "audio": {"address": self._audio_address,
+                      "sample_rate": self._audio_sample_rate,
+                      "channels": self._audio_channels,
+                      "dtype": "int16"},
         })
 
         self._video_q = queue.Queue()

--- a/pepper_wizard/recording/recorder.py
+++ b/pepper_wizard/recording/recorder.py
@@ -1,0 +1,215 @@
+"""Recorder lifecycle orchestrator.
+
+Owns:
+  - A clock-sync probe (run once on each start, optional)
+  - A MkvMuxer
+  - A SidecarWriter
+  - Two consumer threads draining frame/chunk queues into the muxer + sidecar.
+  - Two source threads (VideoSink, AudioSink) owning ZMQ subscribers.
+
+Each Recorder instance corresponds to one toggle-on session (one file triple).
+For repeated start/stop in the same process, see RecordingController.
+"""
+import datetime
+import json
+import os
+import queue
+import threading
+import time
+
+from .audio_sink import AudioSink
+from .clock_sync import probe_clock_sync
+from .muxer import MkvMuxer
+from .sidecar import SidecarWriter
+from .video_sink import VideoSink
+
+
+VIDEO_RES_W = 320
+VIDEO_RES_H = 240
+AUDIO_SAMPLE_RATE = 16000
+AUDIO_CHANNELS = 1
+
+
+class Recorder:
+    def __init__(self, config, session_id, video_address, audio_address,
+                 clock_sync_url=None):
+        self._config = dict(config)
+        self._session_id = session_id or "unset"
+        self._video_address = video_address
+        self._audio_address = audio_address
+        self._clock_sync_url = clock_sync_url
+
+        self._started = False
+        self._stopped = False
+        self._stop_evt = threading.Event()
+        self._lock = threading.Lock()
+
+        self._paths = None
+        self._muxer = None
+        self._sidecar = None
+        self._video_sink = None
+        self._audio_sink = None
+        self._video_q = None
+        self._audio_q = None
+        self._video_drain = None
+        self._audio_drain = None
+        self._t0_ns = None
+
+    def _make_paths(self):
+        out_dir = self._config["output_dir"]
+        os.makedirs(out_dir, exist_ok=True)
+        ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        stem = os.path.join(out_dir, f"session_{self._session_id}_{ts}")
+        return {
+            "mkv": stem + ".mkv",
+            "jsonl": stem + ".jsonl",
+            "clocksync": stem + ".clocksync.json",
+        }
+
+    def start(self):
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+
+        self._paths = self._make_paths()
+        self._t0_ns = time.time_ns()
+
+        clock_sync = None
+        if self._clock_sync_url:
+            clock_sync = probe_clock_sync(self._clock_sync_url, samples=10, timeout_s=2.0)
+
+        with open(self._paths["clocksync"], "w") as f:
+            json.dump(clock_sync, f, indent=2)
+
+        self._muxer = MkvMuxer(
+            path=self._paths["mkv"],
+            video_codec=self._config["video_codec"],
+            video_pix_fmt=self._config["video_pix_fmt"],
+            audio_codec=self._config["audio_codec"],
+            video_size=(VIDEO_RES_W, VIDEO_RES_H),
+            audio_sample_rate=AUDIO_SAMPLE_RATE,
+            audio_channels=AUDIO_CHANNELS,
+        )
+        self._sidecar = SidecarWriter(self._paths["jsonl"])
+        self._sidecar.write_header({
+            "version": 1,
+            "recording_start_utc_ns": self._t0_ns,
+            "session_id": self._session_id,
+            "clock_sync": clock_sync,
+            "video": {"address": self._video_address, "resolution": [VIDEO_RES_W, VIDEO_RES_H], "format": "y8"},
+            "audio": {"address": self._audio_address, "sample_rate": AUDIO_SAMPLE_RATE, "channels": AUDIO_CHANNELS, "dtype": "int16"},
+        })
+
+        self._video_q = queue.Queue()
+        self._audio_q = queue.Queue()
+        self._video_sink = VideoSink(self._video_address, self._video_q)
+        self._audio_sink = AudioSink(self._audio_address, self._audio_q)
+        self._video_sink.start()
+        self._audio_sink.start()
+
+        self._video_drain = threading.Thread(target=self._drain_video, daemon=True)
+        self._audio_drain = threading.Thread(target=self._drain_audio, daemon=True)
+        self._video_drain.start()
+        self._audio_drain.start()
+
+    def _drain_video(self):
+        while not self._stop_evt.is_set() or not self._video_q.empty():
+            try:
+                frame = self._video_q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            pts_ms = max(0, (frame["ingest_utc_ns"] - self._t0_ns) // 1_000_000)
+            self._muxer.write_video_frame(frame["img_bytes"], pts_ms=pts_ms)
+            self._sidecar.write({
+                "type": "video",
+                "ingest_utc_ns": frame["ingest_utc_ns"],
+                "robot_ts_s": frame["robot_ts_s"],
+                "frame_index": frame["frame_index"],
+            })
+
+    def _drain_audio(self):
+        while not self._stop_evt.is_set() or not self._audio_q.empty():
+            try:
+                chunk = self._audio_q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            pts_ms = max(0, (chunk["ingest_utc_ns"] - self._t0_ns) // 1_000_000)
+            self._muxer.write_audio_chunk(chunk["pcm_bytes"], pts_ms=pts_ms)
+            self._sidecar.write({
+                "type": "audio",
+                "ingest_utc_ns": chunk["ingest_utc_ns"],
+                "samples": chunk["samples"],
+                "chunk_index": chunk["chunk_index"],
+            })
+
+    def stop(self):
+        with self._lock:
+            if self._stopped:
+                return self._paths
+            if not self._started:
+                return None
+            self._stopped = True
+
+        if self._video_sink:
+            self._video_sink.stop()
+            self._video_sink.join(timeout=2.0)
+        if self._audio_sink:
+            self._audio_sink.stop()
+            self._audio_sink.join(timeout=2.0)
+        self._stop_evt.set()
+        if self._video_drain:
+            self._video_drain.join(timeout=2.0)
+        if self._audio_drain:
+            self._audio_drain.join(timeout=2.0)
+        if self._muxer:
+            self._muxer.close()
+        if self._sidecar:
+            self._sidecar.close()
+
+        return self._paths
+
+
+class RecordingController:
+    """Wraps Recorder to support repeated start/stop cycles in one process.
+
+    Each toggle-on instantiates a fresh Recorder. Toggle-off finalises it.
+    """
+
+    def __init__(self, config, session_id, video_address, audio_address, clock_sync_url=None):
+        self._config = config
+        self._session_id = session_id
+        self._video_address = video_address
+        self._audio_address = audio_address
+        self._clock_sync_url = clock_sync_url
+        self._current = None
+        self._lock = threading.Lock()
+
+    @property
+    def is_recording(self):
+        return self._current is not None
+
+    def toggle(self):
+        with self._lock:
+            if self._current is None:
+                self._current = Recorder(
+                    config=self._config,
+                    session_id=self._session_id,
+                    video_address=self._video_address,
+                    audio_address=self._audio_address,
+                    clock_sync_url=self._clock_sync_url,
+                )
+                self._current.start()
+                print("Recording started.")
+            else:
+                paths = self._current.stop()
+                self._current = None
+                print(f"Recording stopped: {paths['mkv']}")
+
+    def stop_if_recording(self):
+        with self._lock:
+            if self._current is not None:
+                paths = self._current.stop()
+                self._current = None
+                return paths
+            return None

--- a/pepper_wizard/recording/recorder.py
+++ b/pepper_wizard/recording/recorder.py
@@ -34,7 +34,9 @@ class Recorder:
     def __init__(self, config, session_id, video_address, audio_address,
                  clock_sync_url=None):
         self._config = dict(config)
-        self._session_id = session_id or "unset"
+        # session_id is optional. When not set, file names omit the prefix and
+        # use the timestamp alone (matches the logger's behaviour for log files).
+        self._session_id = session_id or None
         self._video_address = video_address
         self._audio_address = audio_address
         self._clock_sync_url = clock_sync_url
@@ -59,7 +61,10 @@ class Recorder:
         out_dir = self._config["output_dir"]
         os.makedirs(out_dir, exist_ok=True)
         ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        stem = os.path.join(out_dir, f"session_{self._session_id}_{ts}")
+        if self._session_id:
+            stem = os.path.join(out_dir, f"session_{self._session_id}_{ts}")
+        else:
+            stem = os.path.join(out_dir, f"session_{ts}")
         return {
             "mkv": stem + ".mkv",
             "jsonl": stem + ".jsonl",

--- a/pepper_wizard/recording/sidecar.py
+++ b/pepper_wizard/recording/sidecar.py
@@ -1,0 +1,55 @@
+"""Thread-safe JSONL sidecar writer.
+
+Producer threads call write() / write_header(); a single consumer thread drains
+the queue and flushes one JSON object per line. Lines are flushed individually
+so the file remains useful even if the process crashes mid-recording.
+"""
+import json
+import queue
+import threading
+
+
+_SENTINEL = object()
+
+
+class SidecarWriter:
+    def __init__(self, file_path):
+        self._path = file_path
+        self._queue = queue.Queue()
+        self._closed = threading.Event()
+        self._fh = open(file_path, "w", buffering=1)
+        self._consumer = threading.Thread(target=self._drain, daemon=True)
+        self._consumer.start()
+
+    def write_header(self, header):
+        if self._closed.is_set():
+            raise RuntimeError("SidecarWriter is closed")
+        record = {"type": "header", **header}
+        self._queue.put(record)
+
+    def write(self, record):
+        if self._closed.is_set():
+            raise RuntimeError("SidecarWriter is closed")
+        self._queue.put(record)
+
+    def close(self):
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        self._queue.put(_SENTINEL)
+        self._consumer.join(timeout=5.0)
+        try:
+            self._fh.close()
+        except Exception:
+            pass
+
+    def _drain(self):
+        while True:
+            item = self._queue.get()
+            if item is _SENTINEL:
+                return
+            try:
+                line = json.dumps(item, separators=(",", ":"))
+                self._fh.write(line + "\n")
+            except Exception as e:
+                self._fh.write(json.dumps({"type": "error", "msg": str(e)}) + "\n")

--- a/pepper_wizard/recording/video_sink.py
+++ b/pepper_wizard/recording/video_sink.py
@@ -1,0 +1,73 @@
+"""ZMQ video subscriber that timestamps frames and enqueues them.
+
+Subscribes to the PepperBox video PUB stream (default tcp://localhost:5559).
+Wire format: multipart [topic, header, img_data]
+  - topic: bytes (b"video")
+  - header: 8 bytes, packed double, robot wall-clock seconds
+  - img_data: raw bytes (76800 greyscale Y8 320x240, or 153600 YUYV422)
+
+Captures time.time_ns() immediately on recv() return, before any decode.
+Output queue payload:
+  {
+    "ingest_utc_ns": int,
+    "robot_ts_s": float | None,
+    "img_bytes": bytes,
+    "frame_index": int,  # monotonic counter assigned by the sink
+  }
+
+NB: We do NOT use ZMQ CONFLATE here. Recording requires every frame.
+"""
+import struct
+import threading
+import time
+
+import zmq
+
+
+class VideoSink(threading.Thread):
+    def __init__(self, zmq_address, out_queue):
+        super().__init__(daemon=True)
+        self.zmq_address = zmq_address
+        self.out_queue = out_queue
+        self._stop_evt = threading.Event()
+        self._frame_index = 0
+
+    def stop(self):
+        # _stop is an internal slot on threading.Thread; keep our Event as _stop_evt.
+        self._stop_evt.set()
+
+    def run(self):
+        ctx = zmq.Context.instance()
+        sock = ctx.socket(zmq.SUB)
+        sock.connect(self.zmq_address)
+        sock.setsockopt(zmq.SUBSCRIBE, b"video")
+        sock.setsockopt(zmq.RCVTIMEO, 200)
+
+        try:
+            while not self._stop_evt.is_set():
+                try:
+                    msg = sock.recv_multipart()
+                except zmq.Again:
+                    continue
+                ingest_ns = time.time_ns()
+                if len(msg) == 3:
+                    _topic, header, img_data = msg
+                    try:
+                        robot_ts_s = struct.unpack("d", header)[0]
+                    except struct.error:
+                        robot_ts_s = None
+                elif len(msg) == 2:
+                    _topic, img_data = msg
+                    robot_ts_s = None
+                else:
+                    continue
+
+                self.out_queue.put({
+                    "ingest_utc_ns": ingest_ns,
+                    "robot_ts_s": robot_ts_s,
+                    "img_bytes": img_data,
+                    "frame_index": self._frame_index,
+                })
+                self._frame_index += 1
+        finally:
+            sock.close(linger=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ transformers
 torch --extra-index-url https://download.pytorch.org/whl/cpu
 sentencepiece
 anthropic
+av

--- a/tests/test_audio_sink.py
+++ b/tests/test_audio_sink.py
@@ -1,0 +1,68 @@
+"""Unit tests for AudioSink."""
+import queue
+import threading
+import time
+import unittest
+
+import numpy as np
+import zmq
+
+from pepper_wizard.recording.audio_sink import AudioSink
+
+
+class _FakeAudioPublisher(threading.Thread):
+    """Publishes int16 mono 16kHz chunks (170ms = 2720 samples) on a PUB socket."""
+
+    def __init__(self, port, chunk_count, interval_s=0.05):
+        super().__init__(daemon=True)
+        self.port = port
+        self.chunk_count = chunk_count
+        self.interval_s = interval_s
+        self._ctx = zmq.Context.instance()
+        self._sock = self._ctx.socket(zmq.PUB)
+        self._sock.bind(f"tcp://*:{port}")
+        self._stop_evt = threading.Event()
+
+    def run(self):
+        time.sleep(0.1)
+        for i in range(self.chunk_count):
+            if self._stop_evt.is_set():
+                return
+            samples = np.full(2720, i % 32767, dtype=np.int16)
+            self._sock.send(samples.tobytes())
+            time.sleep(self.interval_s)
+
+    def stop(self):
+        self._stop_evt.set()
+        self._sock.close(linger=0)
+
+
+class TestAudioSink(unittest.TestCase):
+    def test_captures_chunks_with_timestamps(self):
+        port = 25563
+        out_queue = queue.Queue()
+        pub = _FakeAudioPublisher(port, chunk_count=5, interval_s=0.02)
+        sink = AudioSink(f"tcp://localhost:{port}", out_queue)
+        sink.start()
+        pub.start()
+        pub.join(timeout=5.0)
+        time.sleep(0.3)
+        sink.stop()
+
+        chunks = []
+        while not out_queue.empty():
+            chunks.append(out_queue.get_nowait())
+
+        self.assertGreaterEqual(len(chunks), 3)
+        for c in chunks:
+            self.assertIn("ingest_utc_ns", c)
+            self.assertIn("pcm_bytes", c)
+            self.assertEqual(c["samples"], 2720)
+            self.assertEqual(len(c["pcm_bytes"]), 2720 * 2)
+        ts = [c["ingest_utc_ns"] for c in chunks]
+        self.assertEqual(ts, sorted(ts))
+        pub.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -1,0 +1,81 @@
+"""Unit tests for the clock-sync probe.
+
+A mock HTTP server with controlled artificial delay simulates the PepperBox
+shim. The probe should estimate the offset within the controlled tolerance.
+"""
+import http.server
+import json
+import socketserver
+import threading
+import time
+import unittest
+
+from pepper_wizard.recording.clock_sync import probe_clock_sync
+
+
+class _FakeShimHandler(http.server.BaseHTTPRequestHandler):
+    SERVER_OFFSET_NS = 0
+    INJECTED_DELAY_S = 0.005
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+    def do_GET(self):
+        if self.path != "/time":
+            self.send_error(404)
+            return
+        time.sleep(self.INJECTED_DELAY_S)
+        body = json.dumps({
+            "now_ns": time.time_ns() + self.SERVER_OFFSET_NS,
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _FakeShim:
+    def __init__(self, offset_ns=0, delay_s=0.005):
+        _FakeShimHandler.SERVER_OFFSET_NS = offset_ns
+        _FakeShimHandler.INJECTED_DELAY_S = delay_s
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), _FakeShimHandler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+class TestClockSyncProbe(unittest.TestCase):
+    def test_zero_offset(self):
+        shim = _FakeShim(offset_ns=0, delay_s=0.005)
+        try:
+            result = probe_clock_sync(f"http://127.0.0.1:{shim.port}/time", samples=8)
+        finally:
+            shim.stop()
+        self.assertIsNotNone(result)
+        self.assertEqual(result["samples"], 8)
+        self.assertLess(abs(result["robot_offset_ns"]), 5_000_000)
+
+    def test_positive_offset(self):
+        # Server clock runs `injected` ahead of wizard. By the spec convention
+        # wizard_utc_ns ≈ robot_clock_ns + robot_offset_ns, the estimate must
+        # therefore be ≈ -injected (subtract the server-ahead bias to recover wizard).
+        injected = 50_000_000
+        shim = _FakeShim(offset_ns=injected, delay_s=0.002)
+        try:
+            result = probe_clock_sync(f"http://127.0.0.1:{shim.port}/time", samples=10)
+        finally:
+            shim.stop()
+        self.assertLess(abs(result["robot_offset_ns"] + injected), 10_000_000)
+
+    def test_unreachable_endpoint_returns_none(self):
+        result = probe_clock_sync("http://127.0.0.1:1/time", samples=3, timeout_s=0.2)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clock_sync.py
+++ b/tests/test_clock_sync.py
@@ -61,9 +61,6 @@ class TestClockSyncProbe(unittest.TestCase):
         self.assertLess(abs(result["robot_offset_ns"]), 5_000_000)
 
     def test_positive_offset(self):
-        # Server clock runs `injected` ahead of wizard. By the spec convention
-        # wizard_utc_ns ≈ robot_clock_ns + robot_offset_ns, the estimate must
-        # therefore be ≈ -injected (subtract the server-ahead bias to recover wizard).
         injected = 50_000_000
         shim = _FakeShim(offset_ns=injected, delay_s=0.002)
         try:

--- a/tests/test_muxer.py
+++ b/tests/test_muxer.py
@@ -56,6 +56,44 @@ class TestMkvMuxer(unittest.TestCase):
             stream_types = {s.type for s in streams}
             self.assertSetEqual(stream_types, {"video", "audio"})
 
+    def test_mkv_duration_matches_pts_span(self):
+        """Regression: dropping rate=30 from add_stream restored correct duration.
+
+        Previously the stream was created with rate=30 which fixed time_base to
+        1/30s and silently overrode our 1/1000 setting; PTS in ms were treated
+        as 1/30s units and the recording played back at 1/33 speed.
+        """
+        muxer = MkvMuxer(
+            path=self.path,
+            video_codec="ffv1",
+            video_pix_fmt="yuv420p",
+            audio_codec="pcm_s16le",
+            video_size=(320, 240),
+            audio_sample_rate=16000,
+            audio_channels=1,
+        )
+        # 50 frames spanning exactly 5000 ms (last frame pts == 5000).
+        for i in range(50):
+            frame_bytes = (np.ones((240, 320), dtype=np.uint8) * 50).tobytes()
+            muxer.write_video_frame(frame_bytes, pts_ms=i * 100)
+        # Matching audio: chunks every 170 ms across 5 s.
+        for i in range(30):
+            samples = np.full(2720, 50, dtype=np.int16)
+            muxer.write_audio_chunk(samples.tobytes(), pts_ms=i * 170)
+        muxer.close()
+
+        with av.open(self.path) as container:
+            # Stream duration in seconds should be ~5 s (the PTS span), not 5*33 s.
+            for s in container.streams:
+                if s.duration is None or s.time_base is None:
+                    continue
+                dur_s = float(s.duration * s.time_base)
+                self.assertLess(dur_s, 10.0,
+                                f"{s.type} stream duration {dur_s:.1f}s implies PTS were "
+                                "interpreted in the wrong time_base.")
+                self.assertGreater(dur_s, 4.0,
+                                   f"{s.type} stream duration {dur_s:.1f}s is too short.")
+
     def test_close_is_idempotent(self):
         muxer = MkvMuxer(
             path=self.path,

--- a/tests/test_muxer.py
+++ b/tests/test_muxer.py
@@ -1,0 +1,74 @@
+"""Unit tests for the PyAV-based MKV muxer.
+
+Feeds the muxer a deterministic stream of greyscale frames (320x240) and
+int16 audio chunks, then re-opens the resulting MKV with PyAV and asserts
+that both streams are present and the file is well-formed.
+"""
+import os
+import tempfile
+import unittest
+
+import av
+import numpy as np
+
+from pepper_wizard.recording.muxer import MkvMuxer
+
+
+class TestMkvMuxer(unittest.TestCase):
+    def setUp(self):
+        self.fd, self.path = tempfile.mkstemp(suffix=".mkv")
+        os.close(self.fd)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def _write_minimal_session(self, video_codec="ffv1", audio_codec="pcm_s16le"):
+        muxer = MkvMuxer(
+            path=self.path,
+            video_codec=video_codec,
+            video_pix_fmt="yuv420p",
+            audio_codec=audio_codec,
+            video_size=(320, 240),
+            audio_sample_rate=16000,
+            audio_channels=1,
+        )
+        N_FRAMES = 10
+        FPS = 5
+        for i in range(N_FRAMES):
+            frame_bytes = (np.ones((240, 320), dtype=np.uint8) * (i * 25)).tobytes()
+            pts = int(i * (1.0 / FPS) * 1000)
+            muxer.write_video_frame(frame_bytes, pts_ms=pts)
+        for i in range(12):
+            samples = np.full(2720, 100 + i, dtype=np.int16)
+            pts = int(i * 170)
+            muxer.write_audio_chunk(samples.tobytes(), pts_ms=pts)
+        muxer.close()
+
+    def test_mkv_has_video_and_audio_streams(self):
+        self._write_minimal_session()
+        self.assertTrue(os.path.exists(self.path))
+        self.assertGreater(os.path.getsize(self.path), 0)
+
+        with av.open(self.path) as container:
+            streams = list(container.streams)
+            self.assertEqual(len(streams), 2)
+            stream_types = {s.type for s in streams}
+            self.assertSetEqual(stream_types, {"video", "audio"})
+
+    def test_close_is_idempotent(self):
+        muxer = MkvMuxer(
+            path=self.path,
+            video_codec="ffv1",
+            video_pix_fmt="yuv420p",
+            audio_codec="pcm_s16le",
+            video_size=(320, 240),
+            audio_sample_rate=16000,
+            audio_channels=1,
+        )
+        muxer.close()
+        muxer.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_muxer.py
+++ b/tests/test_muxer.py
@@ -56,12 +56,14 @@ class TestMkvMuxer(unittest.TestCase):
             stream_types = {s.type for s in streams}
             self.assertSetEqual(stream_types, {"video", "audio"})
 
-    def test_mkv_duration_matches_pts_span(self):
-        """Regression: dropping rate=30 from add_stream restored correct duration.
+    def test_mkv_packet_pts_match_input_pts(self):
+        """Regression: previously frame.pts (intended in ms) was reinterpreted in
+        the codec's default frame rate (1/24s or 1/30s) and rescaled to the
+        stream's 1/1000s, multiplying every recorded pts by ~33-42×. VLC played
+        the result at 1/33 speed, looking exactly like a starving feed.
 
-        Previously the stream was created with rate=30 which fixed time_base to
-        1/30s and silently overrode our 1/1000 setting; PTS in ms were treated
-        as 1/30s units and the recording played back at 1/33 speed.
+        We assert that the LAST video and audio packet's pts (in stream time_base)
+        is within tolerance of the LAST input pts_ms — i.e. no silent rescaling.
         """
         muxer = MkvMuxer(
             path=self.path,
@@ -72,27 +74,39 @@ class TestMkvMuxer(unittest.TestCase):
             audio_sample_rate=16000,
             audio_channels=1,
         )
-        # 50 frames spanning exactly 5000 ms (last frame pts == 5000).
-        for i in range(50):
+        N_FRAMES = 50
+        FRAME_DT_MS = 100
+        last_video_pts_ms = (N_FRAMES - 1) * FRAME_DT_MS  # 4900 ms
+        for i in range(N_FRAMES):
             frame_bytes = (np.ones((240, 320), dtype=np.uint8) * 50).tobytes()
-            muxer.write_video_frame(frame_bytes, pts_ms=i * 100)
-        # Matching audio: chunks every 170 ms across 5 s.
-        for i in range(30):
+            muxer.write_video_frame(frame_bytes, pts_ms=i * FRAME_DT_MS)
+        N_CHUNKS = 30
+        CHUNK_DT_MS = 170
+        last_audio_pts_ms = (N_CHUNKS - 1) * CHUNK_DT_MS  # 4930 ms
+        for i in range(N_CHUNKS):
             samples = np.full(2720, 50, dtype=np.int16)
-            muxer.write_audio_chunk(samples.tobytes(), pts_ms=i * 170)
+            muxer.write_audio_chunk(samples.tobytes(), pts_ms=i * CHUNK_DT_MS)
         muxer.close()
 
         with av.open(self.path) as container:
-            # Stream duration in seconds should be ~5 s (the PTS span), not 5*33 s.
+            last_pts = {"video": None, "audio": None}
+            time_base = {"video": None, "audio": None}
             for s in container.streams:
-                if s.duration is None or s.time_base is None:
-                    continue
-                dur_s = float(s.duration * s.time_base)
-                self.assertLess(dur_s, 10.0,
-                                f"{s.type} stream duration {dur_s:.1f}s implies PTS were "
-                                "interpreted in the wrong time_base.")
-                self.assertGreater(dur_s, 4.0,
-                                   f"{s.type} stream duration {dur_s:.1f}s is too short.")
+                time_base[s.type] = s.time_base
+            for packet in container.demux():
+                if packet.pts is not None and packet.stream.type in last_pts:
+                    last_pts[packet.stream.type] = packet.pts
+
+        # Assert last packet's seconds-equivalent matches input within 200ms.
+        v_seconds = float(last_pts["video"] * time_base["video"])
+        a_seconds = float(last_pts["audio"] * time_base["audio"])
+        self.assertAlmostEqual(v_seconds, last_video_pts_ms / 1000.0, delta=0.2,
+                               msg=f"video last pts {v_seconds:.3f}s does not match "
+                                   f"input {last_video_pts_ms/1000.0:.3f}s — "
+                                   "PTS were silently rescaled.")
+        self.assertAlmostEqual(a_seconds, last_audio_pts_ms / 1000.0, delta=0.2,
+                               msg=f"audio last pts {a_seconds:.3f}s does not match "
+                                   f"input {last_audio_pts_ms/1000.0:.3f}s.")
 
     def test_close_is_idempotent(self):
         muxer = MkvMuxer(

--- a/tests/test_muxer.py
+++ b/tests/test_muxer.py
@@ -56,14 +56,19 @@ class TestMkvMuxer(unittest.TestCase):
             stream_types = {s.type for s in streams}
             self.assertSetEqual(stream_types, {"video", "audio"})
 
-    def test_mkv_packet_pts_match_input_pts(self):
-        """Regression: previously frame.pts (intended in ms) was reinterpreted in
-        the codec's default frame rate (1/24s or 1/30s) and rescaled to the
-        stream's 1/1000s, multiplying every recorded pts by ~33-42×. VLC played
-        the result at 1/33 speed, looking exactly like a starving feed.
+    def test_video_pts_match_input_and_audio_paced_sequentially(self):
+        """Two regressions in one:
 
-        We assert that the LAST video and audio packet's pts (in stream time_base)
-        is within tolerance of the LAST input pts_ms — i.e. no silent rescaling.
+        1. Video PTS used to be silently rescaled by the codec's default rate
+           (1/24s or 1/30s), making 5s recordings play back as 200s. We assert
+           the LAST video packet's seconds-equivalent matches the last input ms.
+
+        2. Audio is a continuous PCM stream — the publisher delivers chunks
+           with variable wall-clock cadence (often bursts) but each chunk is a
+           fixed duration of real audio. Using ingest-time PTS leaves silent
+           gaps between every chunk in the MKV (clicks on playback). We feed
+           the muxer an audio BURST (chunks with dt=5ms) and assert the OUTPUT
+           pts are paced by sample count, not by input ms.
         """
         muxer = MkvMuxer(
             path=self.path,
@@ -74,18 +79,21 @@ class TestMkvMuxer(unittest.TestCase):
             audio_sample_rate=16000,
             audio_channels=1,
         )
+        # Video at 100ms intervals.
         N_FRAMES = 50
         FRAME_DT_MS = 100
         last_video_pts_ms = (N_FRAMES - 1) * FRAME_DT_MS  # 4900 ms
         for i in range(N_FRAMES):
             frame_bytes = (np.ones((240, 320), dtype=np.uint8) * 50).tobytes()
             muxer.write_video_frame(frame_bytes, pts_ms=i * FRAME_DT_MS)
+        # Audio BURST: 30 chunks at 5ms wall-clock dt, but each chunk is 2720
+        # samples (170ms of real PCM @ 16kHz). Total real audio = 29 * 170 = 4930ms.
         N_CHUNKS = 30
-        CHUNK_DT_MS = 170
-        last_audio_pts_ms = (N_CHUNKS - 1) * CHUNK_DT_MS  # 4930 ms
+        SAMPLES_PER_CHUNK = 2720
         for i in range(N_CHUNKS):
-            samples = np.full(2720, 50, dtype=np.int16)
-            muxer.write_audio_chunk(samples.tobytes(), pts_ms=i * CHUNK_DT_MS)
+            samples = np.full(SAMPLES_PER_CHUNK, 50, dtype=np.int16)
+            muxer.write_audio_chunk(samples.tobytes(), pts_ms=i * 5)  # burst
+        expected_audio_last_ms = (N_CHUNKS - 1) * (SAMPLES_PER_CHUNK * 1000) // 16000  # 4930
         muxer.close()
 
         with av.open(self.path) as container:
@@ -97,16 +105,16 @@ class TestMkvMuxer(unittest.TestCase):
                 if packet.pts is not None and packet.stream.type in last_pts:
                     last_pts[packet.stream.type] = packet.pts
 
-        # Assert last packet's seconds-equivalent matches input within 200ms.
         v_seconds = float(last_pts["video"] * time_base["video"])
         a_seconds = float(last_pts["audio"] * time_base["audio"])
         self.assertAlmostEqual(v_seconds, last_video_pts_ms / 1000.0, delta=0.2,
                                msg=f"video last pts {v_seconds:.3f}s does not match "
                                    f"input {last_video_pts_ms/1000.0:.3f}s — "
                                    "PTS were silently rescaled.")
-        self.assertAlmostEqual(a_seconds, last_audio_pts_ms / 1000.0, delta=0.2,
-                               msg=f"audio last pts {a_seconds:.3f}s does not match "
-                                   f"input {last_audio_pts_ms/1000.0:.3f}s.")
+        self.assertAlmostEqual(a_seconds, expected_audio_last_ms / 1000.0, delta=0.2,
+                               msg=f"audio last pts {a_seconds:.3f}s should be paced by "
+                                   f"sample count to {expected_audio_last_ms/1000.0:.3f}s, "
+                                   "not by ingest cadence.")
 
     def test_close_is_idempotent(self):
         muxer = MkvMuxer(

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -113,6 +113,28 @@ class TestRecorder(unittest.TestCase):
             ts = [l["ingest_utc_ns"] for l in lines if l.get("type") == stream]
             self.assertEqual(ts, sorted(ts), f"{stream} timestamps not monotonic")
 
+    def test_no_session_id_drops_prefix(self):
+        """When session_id is None, file names use just the timestamp — no
+        'session_unset_' or similar placeholder."""
+        rec = Recorder(
+            config=self._config(),
+            session_id=None,
+            video_address=f"tcp://localhost:{self.streams.video_port}",
+            audio_address=f"tcp://localhost:{self.streams.audio_port}",
+            clock_sync_url=None,
+        )
+        rec.start()
+        time.sleep(0.5)
+        result = rec.stop()
+        for kind in ("mkv", "jsonl", "clocksync"):
+            stem = os.path.basename(result[kind])
+            self.assertTrue(stem.startswith("session_"),
+                            f"{kind} basename {stem} should start with 'session_'")
+            self.assertNotIn("unset", stem,
+                             f"{kind} basename {stem} should not contain 'unset'")
+            self.assertNotIn("None", stem,
+                             f"{kind} basename {stem} should not contain 'None'")
+
     def test_double_start_is_no_op(self):
         rec = self._new_recorder()
         rec.start()

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,125 @@
+"""Unit tests for the Recorder orchestrator."""
+import json
+import os
+import struct
+import tempfile
+import threading
+import time
+import unittest
+
+import av
+import numpy as np
+import zmq
+
+from pepper_wizard.recording.recorder import Recorder
+
+
+class _FakeStreams:
+    """Spawns video + audio fake publishers on chosen ports."""
+
+    def __init__(self, video_port=25559, audio_port=25563):
+        self.video_port = video_port
+        self.audio_port = audio_port
+        self._stop_evt = threading.Event()
+        self._ctx = zmq.Context.instance()
+        self._vsock = self._ctx.socket(zmq.PUB)
+        self._vsock.bind(f"tcp://*:{video_port}")
+        self._asock = self._ctx.socket(zmq.PUB)
+        self._asock.bind(f"tcp://*:{audio_port}")
+        self._t = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self):
+        time.sleep(0.2)
+        i = 0
+        while not self._stop_evt.is_set():
+            img = (np.ones((240, 320), dtype=np.uint8) * (i % 256)).tobytes()
+            self._vsock.send_multipart([b"video", struct.pack("d", time.time()), img])
+            samples = np.full(2720, i % 1000, dtype=np.int16)
+            self._asock.send(samples.tobytes())
+            i += 1
+            time.sleep(0.05)
+
+    def start(self):
+        self._t.start()
+
+    def stop(self):
+        self._stop_evt.set()
+        self._t.join(timeout=2.0)
+        self._vsock.close(linger=0)
+        self._asock.close(linger=0)
+
+
+class TestRecorder(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.streams = _FakeStreams()
+        self.streams.start()
+
+    def tearDown(self):
+        self.streams.stop()
+
+    def _config(self):
+        return {
+            "record_by_default": False,
+            "output_dir": self.tmp,
+            "video_codec": "ffv1",
+            "video_pix_fmt": "yuv420p",
+            "audio_codec": "pcm_s16le",
+            "container": "mkv",
+        }
+
+    def _new_recorder(self):
+        return Recorder(
+            config=self._config(),
+            session_id="TEST",
+            video_address=f"tcp://localhost:{self.streams.video_port}",
+            audio_address=f"tcp://localhost:{self.streams.audio_port}",
+            clock_sync_url=None,
+        )
+
+    def test_start_stop_produces_triple(self):
+        rec = self._new_recorder()
+        rec.start()
+        time.sleep(1.5)
+        result = rec.stop()
+        self.assertIsNotNone(result)
+        self.assertTrue(os.path.exists(result["mkv"]))
+        self.assertTrue(os.path.exists(result["jsonl"]))
+        self.assertTrue(os.path.exists(result["clocksync"]))
+
+    def test_mkv_is_readable_and_has_both_streams(self):
+        rec = self._new_recorder()
+        rec.start()
+        time.sleep(1.5)
+        result = rec.stop()
+        with av.open(result["mkv"]) as c:
+            stream_types = {s.type for s in c.streams}
+            self.assertSetEqual(stream_types, {"video", "audio"})
+
+    def test_sidecar_has_header_and_records(self):
+        rec = self._new_recorder()
+        rec.start()
+        time.sleep(1.5)
+        result = rec.stop()
+        with open(result["jsonl"]) as f:
+            lines = [json.loads(l) for l in f if l.strip()]
+        self.assertEqual(lines[0]["type"], "header")
+        self.assertIn("recording_start_utc_ns", lines[0])
+        self.assertEqual(lines[0]["session_id"], "TEST")
+        types = {l.get("type") for l in lines[1:]}
+        self.assertIn("video", types)
+        self.assertIn("audio", types)
+        for stream in ("video", "audio"):
+            ts = [l["ingest_utc_ns"] for l in lines if l.get("type") == stream]
+            self.assertEqual(ts, sorted(ts), f"{stream} timestamps not monotonic")
+
+    def test_double_start_is_no_op(self):
+        rec = self._new_recorder()
+        rec.start()
+        rec.start()
+        time.sleep(0.5)
+        rec.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recording_config.py
+++ b/tests/test_recording_config.py
@@ -32,7 +32,7 @@ class TestLoadRecordingConfig(unittest.TestCase):
             path = f.name
         try:
             cfg = load_recording_config(path)
-            self.assertTrue(cfg["record_by_default"])
+            self.assertFalse(cfg["record_by_default"])
             self.assertEqual(cfg["output_dir"], "recordings")
             self.assertEqual(cfg["video_codec"], "ffv1")
             self.assertEqual(cfg["video_pix_fmt"], "yuv420p")
@@ -43,7 +43,7 @@ class TestLoadRecordingConfig(unittest.TestCase):
 
     def test_defaults_when_file_missing(self):
         cfg = load_recording_config("/nonexistent/path/recording.json")
-        self.assertTrue(cfg["record_by_default"])
+        self.assertFalse(cfg["record_by_default"])
         self.assertEqual(cfg["video_codec"], "ffv1")
 
 

--- a/tests/test_recording_config.py
+++ b/tests/test_recording_config.py
@@ -1,0 +1,51 @@
+"""Unit tests for recording config loader."""
+import json
+import os
+import tempfile
+import unittest
+
+from pepper_wizard.config import load_recording_config
+
+
+class TestLoadRecordingConfig(unittest.TestCase):
+    def test_loads_user_values(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({
+                "record_by_default": False,
+                "output_dir": "custom/path",
+                "video_codec": "h264",
+                "container": "mp4",
+            }, f)
+            path = f.name
+        try:
+            cfg = load_recording_config(path)
+            self.assertFalse(cfg["record_by_default"])
+            self.assertEqual(cfg["output_dir"], "custom/path")
+            self.assertEqual(cfg["video_codec"], "h264")
+            self.assertEqual(cfg["container"], "mp4")
+        finally:
+            os.unlink(path)
+
+    def test_defaults_when_missing_fields(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            path = f.name
+        try:
+            cfg = load_recording_config(path)
+            self.assertTrue(cfg["record_by_default"])
+            self.assertEqual(cfg["output_dir"], "recordings")
+            self.assertEqual(cfg["video_codec"], "ffv1")
+            self.assertEqual(cfg["video_pix_fmt"], "yuv420p")
+            self.assertEqual(cfg["audio_codec"], "pcm_s16le")
+            self.assertEqual(cfg["container"], "mkv")
+        finally:
+            os.unlink(path)
+
+    def test_defaults_when_file_missing(self):
+        cfg = load_recording_config("/nonexistent/path/recording.json")
+        self.assertTrue(cfg["record_by_default"])
+        self.assertEqual(cfg["video_codec"], "ffv1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recording_config.py
+++ b/tests/test_recording_config.py
@@ -38,6 +38,9 @@ class TestLoadRecordingConfig(unittest.TestCase):
             self.assertEqual(cfg["video_pix_fmt"], "yuv420p")
             self.assertEqual(cfg["audio_codec"], "pcm_s16le")
             self.assertEqual(cfg["container"], "mkv")
+            self.assertEqual(cfg["video_resolution"], [320, 240])
+            self.assertEqual(cfg["audio_sample_rate"], 16000)
+            self.assertEqual(cfg["audio_channels"], 1)
         finally:
             os.unlink(path)
 

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,0 +1,72 @@
+"""Unit tests for the thread-safe JSONL sidecar writer."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+from pepper_wizard.recording.sidecar import SidecarWriter
+
+
+class TestSidecarWriter(unittest.TestCase):
+    def setUp(self):
+        self.fd, self.path = tempfile.mkstemp(suffix=".jsonl")
+        os.close(self.fd)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def _read_lines(self):
+        with open(self.path, "r") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_writes_header_and_records(self):
+        w = SidecarWriter(self.path)
+        w.write_header({"version": 1, "session_id": "X"})
+        w.write({"type": "video", "ingest_utc_ns": 1, "frame_index": 0})
+        w.write({"type": "video", "ingest_utc_ns": 2, "frame_index": 1})
+        w.close()
+
+        lines = self._read_lines()
+        self.assertEqual(len(lines), 3)
+        self.assertEqual(lines[0]["type"], "header")
+        self.assertEqual(lines[0]["version"], 1)
+        self.assertEqual(lines[0]["session_id"], "X")
+        self.assertEqual(lines[1]["type"], "video")
+        self.assertEqual(lines[2]["frame_index"], 1)
+
+    def test_concurrent_writes_no_torn_lines(self):
+        """Many threads write simultaneously; every line must be valid JSON."""
+        w = SidecarWriter(self.path)
+        w.write_header({"version": 1})
+        N = 8
+        per_thread = 200
+        barrier = threading.Barrier(N)
+
+        def worker(tid):
+            barrier.wait()
+            for i in range(per_thread):
+                w.write({"type": "video", "ingest_utc_ns": time.time_ns(),
+                         "tid": tid, "i": i})
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        w.close()
+
+        lines = self._read_lines()
+        self.assertEqual(len(lines), 1 + N * per_thread)
+
+    def test_close_is_idempotent(self):
+        w = SidecarWriter(self.path)
+        w.write_header({"version": 1})
+        w.close()
+        w.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_video_sink.py
+++ b/tests/test_video_sink.py
@@ -1,0 +1,70 @@
+"""Unit tests for VideoSink — ZMQ subscriber that timestamps and queues frames."""
+import queue
+import struct
+import threading
+import time
+import unittest
+
+import numpy as np
+import zmq
+
+from pepper_wizard.recording.video_sink import VideoSink
+
+
+class _FakeVideoPublisher(threading.Thread):
+    """Publishes greyscale 320x240 frames at a controlled cadence on a PUB socket."""
+
+    def __init__(self, port, frame_count, interval_s=0.05):
+        super().__init__(daemon=True)
+        self.port = port
+        self.frame_count = frame_count
+        self.interval_s = interval_s
+        self._ctx = zmq.Context.instance()
+        self._sock = self._ctx.socket(zmq.PUB)
+        self._sock.bind(f"tcp://*:{port}")
+        self._stop_evt = threading.Event()
+
+    def run(self):
+        time.sleep(0.1)
+        for i in range(self.frame_count):
+            if self._stop_evt.is_set():
+                return
+            img = (np.ones((240, 320), dtype=np.uint8) * (i % 256)).tobytes()
+            header = struct.pack("d", time.time())
+            self._sock.send_multipart([b"video", header, img])
+            time.sleep(self.interval_s)
+
+    def stop(self):
+        self._stop_evt.set()
+        self._sock.close(linger=0)
+
+
+class TestVideoSink(unittest.TestCase):
+    def test_captures_frames_with_timestamps(self):
+        port = 25559
+        out_queue = queue.Queue()
+        pub = _FakeVideoPublisher(port, frame_count=5, interval_s=0.02)
+        sink = VideoSink(f"tcp://localhost:{port}", out_queue)
+        sink.start()
+        pub.start()
+        pub.join(timeout=5.0)
+        time.sleep(0.3)
+        sink.stop()
+
+        frames = []
+        while not out_queue.empty():
+            frames.append(out_queue.get_nowait())
+
+        self.assertGreaterEqual(len(frames), 3, "expected at least 3 frames received")
+        for f in frames:
+            self.assertIn("ingest_utc_ns", f)
+            self.assertIn("robot_ts_s", f)
+            self.assertIn("img_bytes", f)
+            self.assertEqual(len(f["img_bytes"]), 320 * 240)
+        ts = [f["ingest_utc_ns"] for f in frames]
+        self.assertEqual(ts, sorted(ts))
+        pub.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/record_smoke_test.py
+++ b/tools/record_smoke_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Manual end-to-end smoke test for the recording subsystem.
+
+Runs against the live stack. Records for N seconds, then ffprobes the resulting
+MKV and prints sync diagnostics from the sidecar.
+
+Usage (from within pepper-wizard container):
+    python3 tools/record_smoke_test.py
+    python3 tools/record_smoke_test.py --duration 30 --session-id smoke
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+from pepper_wizard.config import load_recording_config
+from pepper_wizard.recording import Recorder
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--duration", type=float, default=10.0)
+    p.add_argument("--session-id", default="smoke")
+    p.add_argument("--video-address", default="tcp://localhost:5559")
+    p.add_argument("--audio-address", default="tcp://localhost:5563")
+    p.add_argument("--clock-sync-url", default="http://localhost:5000/time")
+    p.add_argument("--config", default="pepper_wizard/config/recording.json")
+    args = p.parse_args()
+
+    cfg = load_recording_config(args.config)
+    print(f"Config: {cfg}")
+
+    rec = Recorder(
+        config=cfg,
+        session_id=args.session_id,
+        video_address=args.video_address,
+        audio_address=args.audio_address,
+        clock_sync_url=args.clock_sync_url,
+    )
+    print(f"Starting recording for {args.duration}s...")
+    rec.start()
+    time.sleep(args.duration)
+    paths = rec.stop()
+
+    print("\n=== Files written ===")
+    for k, v in paths.items():
+        size = os.path.getsize(v) if os.path.exists(v) else 0
+        print(f"  {k}: {v} ({size} bytes)")
+
+    print("\n=== ffprobe ===")
+    try:
+        r = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_format", "-show_streams",
+             "-of", "json", paths["mkv"]],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0:
+            info = json.loads(r.stdout)
+            for s in info.get("streams", []):
+                print(f"  stream {s['index']}: {s['codec_type']} / {s['codec_name']} "
+                      f"duration={s.get('duration', '?')}")
+            print(f"  format duration: {info.get('format', {}).get('duration', '?')}")
+        else:
+            print(f"  ffprobe failed: {r.stderr}")
+    except FileNotFoundError:
+        print("  ffprobe not installed")
+
+    print("\n=== Sidecar summary ===")
+    with open(paths["jsonl"]) as f:
+        lines = [json.loads(l) for l in f if l.strip()]
+    header = lines[0]
+    print(f"  recording_start_utc_ns: {header['recording_start_utc_ns']}")
+    print(f"  clock_sync: {header.get('clock_sync')}")
+    counts = {}
+    for l in lines[1:]:
+        counts[l.get("type", "?")] = counts.get(l.get("type", "?"), 0) + 1
+    print(f"  records: {counts}")
+    if counts.get("video", 0) > 0 and counts.get("audio", 0) > 0:
+        print("  PASS: both streams captured")
+        return 0
+    print("  FAIL: missing stream(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# add synchronised audio/video recording

Records robot video (`:5559`) + audio (`:5563`) to MKV with a sidecar JSONL of wall-clock UTC ns per frame/chunk. Sidecar is the temporal-alignment artefact; MKV is for playback.

## menu

`Record [○ Off]` toggles to `Record [● REC]`. Each toggle-on produces a triple in `recordings/`:

```
session_<utc>.mkv          ffv1 + pcm_s16le in matroska
session_<utc>.jsonl        per-frame ingest_utc_ns + robot_ts_s, line-flushed
session_<utc>.clocksync.json   robot↔wizard offset (null until PepperBox has /time)
```

`--session-id P01` prepends to the stem. `record_by_default: false` in `recording.json`.

## tested

- 51 unit tests in container, all green. Regression coverage for two pts-rescaling bugs caught on real Pepper (video at 1/24 s, audio at 1/16000 s).
- `tools/record_smoke_test.py --duration 10` against live stack ffprobes the output.
- Manual: real Pepper, wake/talk/toggle, plays in VLC at real-time with sync.

## not touched / deferred

- Perception, STT, LLM, teleop, tracking — unchanged.
- No `/time` endpoint on PepperBox → `clock_sync: null` for now (wall-clock NTP only).
- Disk-full handling, gap records.
