### PR TITLE
dev overlay: bind-mount host pynaoqi into naoqi-side services

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       - ../PepperBox/src:/home/pepperdev/src                 # sim shim + setup_wizard (live editing)
       - ../PepperBox/.qibullet:/home/pepperdev/.qibullet     # persist qibullet asset cache across `compose down`
       - ../PepperBox/entrypoint.sh:/home/pepperdev/entrypoint.sh:ro  # sibling's sim/physical-switching entrypoint
-      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro  # proprietary SDK lives on host, never in image; populated by PepperBox/setup.sh
+      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro  # proprietary SDK lives on host, not in image; populated by PepperBox/setup.sh
     environment:
       - DISPLAY=${DISPLAY}
       - QIBULLET_GUI=${QIBULLET_GUI:-false}                  # headless by default; set QIBULLET_GUI=true for the pybullet window

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,7 @@ services:
       - ../PepperBox/src:/home/pepperdev/src                 # sim shim + setup_wizard (live editing)
       - ../PepperBox/.qibullet:/home/pepperdev/.qibullet     # persist qibullet asset cache across `compose down`
       - ../PepperBox/entrypoint.sh:/home/pepperdev/entrypoint.sh:ro  # sibling's sim/physical-switching entrypoint
+      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro  # proprietary SDK lives on host, never in image; populated by PepperBox/setup.sh
     environment:
       - DISPLAY=${DISPLAY}
       - QIBULLET_GUI=${QIBULLET_GUI:-false}                  # headless by default; set QIBULLET_GUI=true for the pybullet window
@@ -37,6 +38,7 @@ services:
     volumes:
       - ./robot.env:/home/pepperdev/py3-naoqi-bridge/robot.env
       - ../PepperBox/py3-naoqi-bridge:/home/pepperdev/py3-naoqi-bridge
+      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro
     env_file:
       - robot.env
     environment:
@@ -50,6 +52,7 @@ services:
     volumes:
       - ./robot.env:/home/pepperdev/py3-naoqi-bridge/robot.env
       - ../PepperBox/py3-naoqi-bridge:/home/pepperdev/py3-naoqi-bridge
+      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro
     env_file:
       - robot.env
     environment:


### PR DESCRIPTION
## Summary

- Three NAOqi-side services in the dev overlay (\`pepper-robot-env\`, \`proprioception-service\`, \`audio-publisher-service\`) now bind-mount \`\${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64\` onto \`/opt/pynaoqi-python2.7-2.5.7.1-linux64\` (read-only).
- Companion change to the PepperBox runtime-supplied-SDK PR; should land *after* that one merges, since the local \`pepper-box\` image needs to be the new one for this bind-mount to be load-bearing.

## Test plan

- [x] Full dev-overlay stack against the lab Pepper (2026-05-11): \`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d\`.
- [x] All seven services come up; \`stt-service\` healthy, \`perception-service\` ready on GPU, \`pepper-wizard\` initialised with \`PerceptionClient\` → \`:5557\`, \`StateClient\` → \`:5560\`, \`VisionClient\` → \`:5559\`, and \`ExternalCommandListener\` bound on \`:5561\`.
- [x] Pepper-wizard menu rendered with real-robot battery (88%) and graceful degradation correct (joystick absent → Teleop defaults to Keyboard).