### PR TITLE
MVP base compose: bind-mount host pynaoqi via ./setup.sh, fix python path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ roadmap/
 
 # Images
 *.png
+
+# Recordings from sessions
+recordings/

--- a/README.md
+++ b/README.md
@@ -43,9 +43,17 @@ The `pepper-wizard` application itself is structured as follows:
 
 > **OS Compatibility**: PepperWizard uses `network_mode: host` and host PulseAudio for the microphone, so it currently requires **Linux**. macOS and Windows are on the long-term roadmap but are not supported for the MVP.
 
-> The NAOqi bridge runs from the public `jwgcurrie/pepper-box` image — Docker pulls it automatically on first run.
+> The NAOqi bridge runs from the public `jwgcurrie/pepper-box` image. The proprietary `pynaoqi` SDK isn't bundled; you supply it once at runtime via the bundled `./setup.sh` script (step 1 below).
 
-### 1. Point PepperWizard at your robot
+### 1. Install the NAOqi SDK locally
+
+```bash
+./setup.sh
+```
+
+This fetches the SDK from Aldebaran's CDN (with a Wayback Machine fallback), verifies the SHA256, and extracts it to `~/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64/`. `docker-compose.yml` bind-mounts that directory into the bridge container at runtime. Idempotent; re-running after success is a no-op.
+
+### 2. Point PepperWizard at your robot
 
 The connection is configured via a `robot.env` file. Copy the example and edit if your robot isn't at the lab default:
 
@@ -59,7 +67,7 @@ NAOQI_IP=192.168.123.50   # robot IP (use 127.0.0.1 for a local NAOqi sim)
 NAOQI_PORT=9559           # 9559 on physical robots, sim-specific otherwise
 ```
 
-### 2. Build and run (MVP)
+### 3. Build and run (MVP)
 
 ```bash
 docker compose up -d --build                 # build images and start the background services
@@ -73,7 +81,7 @@ Teleop defaults to **Keyboard** mode; tracking entries are hidden if the optiona
 
 > **Why the `stop` step?** `docker compose up` instantiates `pepper-wizard` as a background container that binds port 5561 for external commands. `docker compose run` creates a second interactive container that needs the same port. Stopping the first frees it for the second; both use `network_mode: host`.
 
-### 3. Developer stack (optional)
+### 4. Developer stack (optional)
 
 The developer overlay (`docker-compose.dev.yml`) adds joystick teleop, proprioception, optional GPU vision tracking, and swaps the physical-robot shim for the **qiBullet simulator** baked into `pepper-box:latest`. It requires a sibling checkout of [`PepperBox`](https://github.com/Action-Prediction-Lab/PepperBox); [`PepperPerception`](https://github.com/Action-Prediction-Lab/PepperPerception) is optional (the bind-mount is auto-created empty if absent, and the perception service itself is gated behind `--profile gpu`).
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # PepperWizard
 
-PepperWizard is a Python 3 command-line application for teleoperating the SoftBank Pepper robot. It provides an interactive TUI for voice interaction, teleop, and scripted behaviours, backed by a Dockerised NAOqi bridge.
+PepperWizard is a Python 3 command-line application for teleoperating the SoftBank Pepper robot. It provides an interactive TUI for verbal interaction, teleoperation, locomotion, visual-servoing, recording video/audio streams, and scripted behaviours.
 
 ## Features
 
 *   **Modern Bridge Architecture:** Integrates with `PepperBox` to wrap the legacy Python 2.7 / NAOqi SDK in a Docker container, so your code stays in Python 3.
-*   **Self-contained MVP:** Three-service compose runs on any Linux + Docker host that can reach the robot on the network. Optional services (joystick, vision tracking, proprioception) live in a developer overlay.
+*   **Self-contained MVP:** Three-service compose runs on any Linux + Docker host that can reach the robot on the network. Optional services (joystick, vision servoing, proprioception) live in a developer overlay.
 *   **Talk Modes:** A unified interface for speech and animation, with **push-to-talk voice input** (CPU Whisper), **slash-command autocomplete**, **spellcheck**, and **emoticon animation triggers**.
 *   **Teleop:** Keyboard by default; joystick (DualShock via [Dualshock-ZMQ](https://github.com/Action-Prediction-Lab/Dualshock-ZMQ)) when the dev overlay is enabled.
 *   **Experimental Logging:** Timestamped JSONL logging of all interactions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,18 @@
 # MVP stack for PepperWizard → physical Pepper robot.
 #
-# This compose is self-contained: it does NOT require sibling checkouts of
-# PepperBox or PepperPerception. `pepper-robot-env` uses the baked-in NAOqi
-# shim from the published image; `pepper-wizard` pip-installs the bridge at
-# build time (see Dockerfile). Tracking and proprioception services are
-# optional and live in `docker-compose.dev.yml` — enable them with:
+# This compose does NOT require sibling checkouts of PepperBox or
+# PepperPerception. `pepper-robot-env` uses the published NAOqi-bridge image
+# and bind-mounts the user-supplied pynaoqi SDK from $HOME/.pepperbox; that
+# directory is populated by running `./setup.sh` once. Tracking and
+# proprioception services are optional and live in `docker-compose.dev.yml`,
+# enable them with:
 #
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 #
-# Robot connection: copy `robot.env.example` to `robot.env` and set NAOQI_IP.
+# First-run setup:
+#   ./setup.sh                                       # one-time, fetches pynaoqi
+#   cp robot.env.example robot.env && $EDITOR robot.env
+#   docker compose up
 
 services:
   pepper-robot-env:
@@ -16,11 +20,12 @@ services:
     network_mode: host
     volumes:
       - ./robot.env:/home/pepperdev/py3-naoqi-bridge/robot.env
+      - ${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro
     env_file:
       - robot.env
     environment:
       - PYTHONUNBUFFERED=1
-    command: [ "/home/pepperdev/.pyenv/versions/2.7.18/bin/python", "/home/pepperdev/py3-naoqi-bridge/shim_server.py" ]
+    command: [ "/home/pepperdev/entrypoint.sh" ]
     restart: on-failure
 
   pepper-wizard:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # This compose does NOT require sibling checkouts of PepperBox or
 # PepperPerception. `pepper-robot-env` uses the published NAOqi-bridge image
 # and bind-mounts the user-supplied pynaoqi SDK from $HOME/.pepperbox; that
-# directory is populated by running `./setup.sh` once. Tracking and
+# directos, proprry is populated by running `./setup.sh` once. Tracking and
 # proprioception services are optional and live in `docker-compose.dev.yml`,
 # enable them with:
 #

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Prepare PepperBox for physical-robot use by ensuring the SoftBank Robotics
+# pynaoqi SDK is available locally. The SDK is proprietary and never built into
+# the image; it lives under $HOME/.pepperbox on the user's machine and is
+# bind-mounted into the container at runtime.
+#
+# Sim-only users do not need this script; qibullet is already in the image.
+#
+# Idempotent: re-running after success is a no-op.
+
+set -euo pipefail
+
+readonly PYNAOQI_FILENAME="pynaoqi-python2.7-2.5.7.1-linux64.tar.gz"
+readonly PYNAOQI_DIR_NAME="pynaoqi-python2.7-2.5.7.1-linux64"
+readonly PYNAOQI_SHA256="d2060ad69f87481f0dda82ede6c70c3b65afa6f1bf06e2c107c2e373d26d92c2"
+readonly PYNAOQI_SIZE=51743305
+readonly PRIMARY_URL="https://community-static.aldebaran.com/resources/2.5.10/Python%20SDK/${PYNAOQI_FILENAME}"
+readonly WAYBACK_URL="https://web.archive.org/web/20240301010123if_/${PRIMARY_URL}"
+
+PEPPERBOX_HOME="${PEPPERBOX_HOME:-$HOME/.pepperbox}"
+readonly TARBALL_PATH="${PEPPERBOX_HOME}/${PYNAOQI_FILENAME}"
+readonly SDK_DIR="${PEPPERBOX_HOME}/${PYNAOQI_DIR_NAME}"
+readonly NAOQI_PY_PATH="${SDK_DIR}/lib/python2.7/site-packages/naoqi.py"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "[!!] required command not found: $1" >&2
+        exit 1
+    }
+}
+require curl
+require sha256sum
+require tar
+
+mkdir -p "${PEPPERBOX_HOME}"
+
+echo "PepperBox setup"
+echo "==============="
+echo "SDK home: ${PEPPERBOX_HOME}"
+echo
+
+if [[ -f "${NAOQI_PY_PATH}" ]]; then
+    echo "[ok] pynaoqi already extracted at ${SDK_DIR}"
+    echo "[ok] nothing to do"
+    exit 0
+fi
+
+verify_sha() {
+    local file="$1"
+    local actual
+    actual=$(sha256sum "${file}" | awk '{print $1}')
+    [[ "${actual}" == "${PYNAOQI_SHA256}" ]]
+}
+
+if [[ -f "${TARBALL_PATH}" ]]; then
+    echo "[..] found existing tarball at ${TARBALL_PATH}; verifying SHA256..."
+    if verify_sha "${TARBALL_PATH}"; then
+        echo "[ok] hash matches"
+    else
+        echo "[!!] hash mismatch on local tarball"
+        echo "    expected: ${PYNAOQI_SHA256}"
+        echo "    got:      $(sha256sum "${TARBALL_PATH}" | awk '{print $1}')"
+        echo "    delete or replace ${TARBALL_PATH} and re-run."
+        exit 1
+    fi
+else
+    echo "[..] downloading pynaoqi from Aldebaran CDN..."
+    if curl --fail --location --show-error --max-time 300 \
+            -o "${TARBALL_PATH}.tmp" "${PRIMARY_URL}"; then
+        mv "${TARBALL_PATH}.tmp" "${TARBALL_PATH}"
+        echo "[ok] download complete (primary)"
+    else
+        rm -f "${TARBALL_PATH}.tmp"
+        echo "[!!] primary CDN unreachable; trying Wayback Machine snapshot..."
+        if curl --fail --location --show-error --max-time 300 \
+                -o "${TARBALL_PATH}.tmp" "${WAYBACK_URL}"; then
+            mv "${TARBALL_PATH}.tmp" "${TARBALL_PATH}"
+            echo "[ok] download complete (wayback)"
+        else
+            rm -f "${TARBALL_PATH}.tmp"
+            cat <<EOF >&2
+
+[!!] both canonical sources are unreachable.
+
+    The pynaoqi SDK this script needs:
+      filename: ${PYNAOQI_FILENAME}
+      size:     ${PYNAOQI_SIZE} bytes
+      sha256:   ${PYNAOQI_SHA256}
+
+    Obtain it from any source that produces a byte-identical file
+    (verifiable against the SHA256 above), place it at:
+      ${TARBALL_PATH}
+    and re-run this script.
+EOF
+            exit 1
+        fi
+    fi
+
+    echo "[..] verifying SHA256..."
+    if verify_sha "${TARBALL_PATH}"; then
+        echo "[ok] hash matches"
+    else
+        echo "[!!] downloaded file failed hash check; refusing to extract"
+        echo "    expected: ${PYNAOQI_SHA256}"
+        echo "    got:      $(sha256sum "${TARBALL_PATH}" | awk '{print $1}')"
+        rm -f "${TARBALL_PATH}"
+        exit 1
+    fi
+fi
+
+echo "[..] extracting to ${SDK_DIR}..."
+tar -xzf "${TARBALL_PATH}" -C "${PEPPERBOX_HOME}"
+
+if [[ ! -f "${NAOQI_PY_PATH}" ]]; then
+    echo "[!!] extraction completed but expected layout is missing"
+    echo "    looked for: ${NAOQI_PY_PATH}"
+    exit 1
+fi
+
+echo "[ok] pynaoqi extracted; physical-robot bridge ready"
+echo
+echo "Next steps:"
+echo "  Sim:       NAOQI_IP=127.0.0.1 ./run.sh"
+echo "  Physical:  NAOQI_IP=<robot.ip> NAOQI_PORT=9559 ./run.sh"

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Prepare PepperBox for physical-robot use by ensuring the SoftBank Robotics
+# Prepare PepperWizard for physical-robot use by ensuring the SoftBank Robotics
 # pynaoqi SDK is available locally. The SDK is proprietary and never built into
 # the image; it lives under $HOME/.pepperbox on the user's machine and is
 # bind-mounted into the container at runtime.


### PR DESCRIPTION
## Summary

Repairs the fresh-clone MVP path that silently broke after `jwgcurrie/pepper-box:01-26-latest` was rebuilt without the bundled SoftBank SDK. Three changes:

- **Add `setup.sh` to PepperWizard root** (copy of PepperBox's version). Fetches pynaoqi from Aldebaran's CDN with a Wayback Machine fallback, verifies SHA256, extracts to `~/.pepperbox/`. Keeps PepperWizard self-contained — no sibling PepperBox checkout needed for the MVP path.
- **`docker-compose.yml` base service `pepper-robot-env`:**
  - Add bind-mount `${HOME}/.pepperbox/pynaoqi-python2.7-2.5.7.1-linux64:/opt/pynaoqi-python2.7-2.5.7.1-linux64:ro` so the bridge can find `naoqi.py` at runtime.
  - Change `command` from the old pyenv path (`/home/pepperdev/.pyenv/versions/2.7.18/bin/python ...`) to `/home/pepperdev/entrypoint.sh`. The pyenv path was a stale reference; the published image now ships python2 via apt, and `entrypoint.sh` provides the proper sim/physical dispatch plus pre-flight checks.
- **README:** new "1. Install the NAOqi SDK locally" step (renumbers subsequent steps); updated header comment to reflect runtime-supplied SDK.

## Why this is needed

Pre-fix, a fresh-clone user running `git clone && docker compose up` would build for ~5 min, then watch `pepper-robot-env` fail to create the container at all:

```
OCI runtime create failed: exec: "/home/pepperdev/.pyenv/versions/2.7.18/bin/python":
  no such file or directory
```

`pepper-wizard` (which depends on `pepper-robot-env` being started) would never come up. Verified on a clean desktop with cached `jwgcurrie/pepper-box:01-26-latest` removed.

## Test plan

- [x] Fresh clone into `~/code/PepperWizard-setup-test/PepperWizard` on a separate machine.
- [x] `./setup.sh` — fetches pynaoqi in ~5s, hash-verifies, extracts to `~/.pepperbox/`.
- [x] `docker compose up -d` — all three MVP services come up: `pepper-robot-env`, `stt-service` (healthy), `pepper-wizard`.
- [x] Shim API returns real robot data: `ALBattery.getBatteryCharge` → 58, `ALMotion.getRobotPosition` → real non-origin coords.
- [x] Wizard CLI renders main menu with battery 58%, "External Command Listener bound to tcp://*:5561".

## Out of scope

- Bumping the pre-flight TCP timeout to be more forgiving of WiFi-connected Peppers — separate small PR against PepperBox.